### PR TITLE
feat: movie loading and coroutine Repository cache variants

### DIFF
--- a/tasks/build.gradle
+++ b/tasks/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     ksp("io.github.antonbutov:code-factory-processor:1.0.1")
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlin:kotlin-test:1.9.24"
 }

--- a/tasks/build.gradle
+++ b/tasks/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlin:kotlin-test:1.9.24"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3"
 }
 
 test {

--- a/tasks/build.gradle
+++ b/tasks/build.gradle
@@ -9,3 +9,9 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlin:kotlin-test:1.9.24"
 }
+
+test {
+    testLogging {
+        showStandardStreams = true
+    }
+}

--- a/tasks/src/main/kotlin/ru/butov/tasks/coroutines/Repository.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/coroutines/Repository.kt
@@ -1,0 +1,28 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+interface BackendApi {
+    // very long call
+    suspend fun apiCall(): String
+}
+
+// Сделать код-ревью и рефакторинг по необходимости
+class Repository(private val backendApi: BackendApi) {
+    @Volatile
+    private var cache: String? = null
+    private val mutex = Mutex()
+
+    suspend fun apiCallOrCache(): String {
+        if (cache == null) {
+            mutex.withLock {
+                if (cache != null) {
+                    return cache!!
+                }
+                cache = backendApi.apiCall()
+            }
+        }
+        return cache!!
+    }
+}

--- a/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryAsyncLazy.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryAsyncLazy.kt
@@ -1,33 +1,22 @@
 package ru.butov.tasks.coroutines
 
-import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
-import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.async
 
 /**
- * Single-flight без CoroutineScope в конструкторе.
- *
- * Чистый async(start = LAZY) всегда требует scope — без него зависания
- * через coroutineScope при гонках. Здесь тот же смысл через CompletableDeferred:
- * первый вызов запускает apiCall, остальные await() ждут один Deferred.
+ * Официальный паттерн из kotlinx.coroutines:
+ * async(start = LAZY) как замена lazy для suspend.
+ * Корутина создаётся сразу, apiCall стартует при первом await().
  */
 class RepositoryAsyncLazy(
     private val backendApi: BackendApi,
+    scope: CoroutineScope,
 ) {
-    private val deferred = AtomicReference<Deferred<String>?>(null)
-
-    suspend fun apiCallOrCache(): String {
-        deferred.get()?.let { return it.await() }
-
-        val created = CompletableDeferred<String>()
-        if (deferred.compareAndSet(null, created)) {
-            try {
-                created.complete(backendApi.apiCall())
-            } catch (e: Throwable) {
-                created.completeExceptionally(e)
-                throw e
-            }
-        }
-        return deferred.get()!!.await()
+    private val deferred: Deferred<String> = scope.async(start = CoroutineStart.LAZY) {
+        backendApi.apiCall()
     }
+
+    suspend fun apiCallOrCache(): String = deferred.await()
 }

--- a/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryAsyncLazy.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryAsyncLazy.kt
@@ -1,0 +1,22 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+
+/**
+ * Официальный паттерн из kotlinx.coroutines:
+ * async(start = LAZY) как замена lazy для suspend.
+ * Корутина создаётся сразу, apiCall стартует при первом await().
+ */
+class RepositoryAsyncLazy(
+    private val backendApi: BackendApi,
+    scope: CoroutineScope,
+) {
+    private val deferred: Deferred<String> = scope.async(start = CoroutineStart.LAZY) {
+        backendApi.apiCall()
+    }
+
+    suspend fun apiCallOrCache(): String = deferred.await()
+}

--- a/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryAsyncLazy.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryAsyncLazy.kt
@@ -1,22 +1,33 @@
 package ru.butov.tasks.coroutines
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
+import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Официальный паттерн из kotlinx.coroutines:
- * async(start = LAZY) как замена lazy для suspend.
- * Корутина создаётся сразу, apiCall стартует при первом await().
+ * Single-flight без CoroutineScope в конструкторе.
+ *
+ * Чистый async(start = LAZY) всегда требует scope — без него зависания
+ * через coroutineScope при гонках. Здесь тот же смысл через CompletableDeferred:
+ * первый вызов запускает apiCall, остальные await() ждут один Deferred.
  */
 class RepositoryAsyncLazy(
     private val backendApi: BackendApi,
-    scope: CoroutineScope,
 ) {
-    private val deferred: Deferred<String> = scope.async(start = CoroutineStart.LAZY) {
-        backendApi.apiCall()
-    }
+    private val deferred = AtomicReference<Deferred<String>?>(null)
 
-    suspend fun apiCallOrCache(): String = deferred.await()
+    suspend fun apiCallOrCache(): String {
+        deferred.get()?.let { return it.await() }
+
+        val created = CompletableDeferred<String>()
+        if (deferred.compareAndSet(null, created)) {
+            try {
+                created.complete(backendApi.apiCall())
+            } catch (e: Throwable) {
+                created.completeExceptionally(e)
+                throw e
+            }
+        }
+        return deferred.get()!!.await()
+    }
 }

--- a/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryFlow.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryFlow.kt
@@ -1,12 +1,10 @@
 package ru.butov.tasks.coroutines
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -16,11 +14,24 @@ interface BackendApiFlow {
 }
 
 // Сделать код-ревью и рефакторинг по необходимости
-class RepositoryFLow(private val backendApiFLow: BackendApiFlow) {
-    private val cache: Flow<String> by lazy { backendApiFLow.apiCall() }
+class RepositoryFlow(private val backendApiFlow: BackendApiFlow) {
+    private val _cache = MutableStateFlow<String?>(null)
+    val cache = _cache.asStateFlow()
     private val mutex = Mutex()
 
-    fun apiCallOrCache(): Flow<String> {
-        return cache
+    fun apiCallOrCache(): Flow<String> = flow {
+        _cache.value?.let {
+            emit(it)
+            return@flow
+        }
+        mutex.withLock {
+            _cache.value?.let {
+                emit(it)
+                return@withLock
+            }
+            val value = backendApiFlow.apiCall().first()
+            _cache.value = value
+            emit(value)
+        }
     }
 }

--- a/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryFlow.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryFlow.kt
@@ -1,12 +1,11 @@
 package ru.butov.tasks.coroutines
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.stateIn
 
 interface BackendApiFlow {
     // very long call
@@ -14,24 +13,16 @@ interface BackendApiFlow {
 }
 
 // Сделать код-ревью и рефакторинг по необходимости
-class RepositoryFlow(private val backendApiFlow: BackendApiFlow) {
-    private val _cache = MutableStateFlow<String?>(null)
-    val cache = _cache.asStateFlow()
-    private val mutex = Mutex()
+class RepositoryFlow(
+    backendApiFlow: BackendApiFlow,
+    scope: CoroutineScope,
+) {
+    val cache: StateFlow<String?> = backendApiFlow.apiCall()
+        .stateIn(
+            scope = scope,
+            started = SharingStarted.Lazily,
+            initialValue = null,
+        )
 
-    fun apiCallOrCache(): Flow<String> = flow {
-        _cache.value?.let {
-            emit(it)
-            return@flow
-        }
-        mutex.withLock {
-            _cache.value?.let {
-                emit(it)
-                return@withLock
-            }
-            val value = backendApiFlow.apiCall().first()
-            _cache.value = value
-            emit(value)
-        }
-    }
+    fun apiCallOrCache(): Flow<String> = cache.filterNotNull()
 }

--- a/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryFlow.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryFlow.kt
@@ -1,0 +1,26 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+interface BackendApiFlow {
+    // very long call
+    fun apiCall(): Flow<String>
+}
+
+// Сделать код-ревью и рефакторинг по необходимости
+class RepositoryFLow(private val backendApiFLow: BackendApiFlow) {
+    private val cache: Flow<String> by lazy { backendApiFLow.apiCall() }
+    private val mutex = Mutex()
+
+    fun apiCallOrCache(): Flow<String> {
+        return cache
+    }
+}

--- a/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryFlowCold.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryFlowCold.kt
@@ -1,8 +1,6 @@
 package ru.butov.tasks.coroutines
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.sync.Mutex
@@ -13,22 +11,22 @@ import kotlinx.coroutines.sync.withLock
  * Кэш пишется вручную, API вызывается один раз при конкурентных collect.
  */
 class RepositoryFlowCold(private val backendApiFlow: BackendApiFlow) {
-    private val _cache = MutableStateFlow<String?>(null)
-    val cache = _cache.asStateFlow()
+    @Volatile
+    private var cache: String? = null
     private val mutex = Mutex()
 
     fun apiCallOrCache(): Flow<String> = flow {
-        _cache.value?.let {
+        cache?.let {
             emit(it)
             return@flow
         }
         mutex.withLock {
-            _cache.value?.let {
+            cache?.let {
                 emit(it)
                 return@withLock
             }
             val value = backendApiFlow.apiCall().first()
-            _cache.value = value
+            cache = value
             emit(value)
         }
     }

--- a/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryFlowCold.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryFlowCold.kt
@@ -1,0 +1,35 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Cold Flow + Mutex: без CoroutineScope.
+ * Кэш пишется вручную, API вызывается один раз при конкурентных collect.
+ */
+class RepositoryFlowCold(private val backendApiFlow: BackendApiFlow) {
+    private val _cache = MutableStateFlow<String?>(null)
+    val cache = _cache.asStateFlow()
+    private val mutex = Mutex()
+
+    fun apiCallOrCache(): Flow<String> = flow {
+        _cache.value?.let {
+            emit(it)
+            return@flow
+        }
+        mutex.withLock {
+            _cache.value?.let {
+                emit(it)
+                return@withLock
+            }
+            val value = backendApiFlow.apiCall().first()
+            _cache.value = value
+            emit(value)
+        }
+    }
+}

--- a/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryLazy.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryLazy.kt
@@ -1,0 +1,21 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+
+/**
+ * lazy + async: Deferred создаётся один раз (thread-safe),
+ * все await() ждут один и тот же вызов API.
+ * Scope нужен, потому что async запускает корутину.
+ */
+class RepositoryLazy(
+    private val backendApi: BackendApi,
+    private val scope: CoroutineScope,
+) {
+    private val deferred: Lazy<Deferred<String>> = lazy {
+        scope.async { backendApi.apiCall() }
+    }
+
+    suspend fun apiCallOrCache(): String = deferred.value.await()
+}

--- a/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryLazy.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryLazy.kt
@@ -13,9 +13,9 @@ class RepositoryLazy(
     private val backendApi: BackendApi,
     private val scope: CoroutineScope,
 ) {
-    private val deferred: Lazy<Deferred<String>> = lazy {
+    private val deferred: Deferred<String> by lazy {
         scope.async { backendApi.apiCall() }
     }
 
-    suspend fun apiCallOrCache(): String = deferred.value.await()
+    suspend fun apiCallOrCache(): String = deferred.await()
 }

--- a/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryLazySuspend.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/coroutines/RepositoryLazySuspend.kt
@@ -1,0 +1,51 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Suspend-аналог lazy: инициализатор вызывается один раз,
+ * без CoroutineScope и без Deferred.
+ * См. kotlinx.coroutines#706 / паттерн LazySuspend.
+ */
+fun <T> lazySuspend(initializer: suspend () -> T): LazySuspend<T> = LazySuspend(initializer)
+
+class LazySuspend<T>(private val initializer: suspend () -> T) {
+    @Volatile
+    private var cached: Any? = UNINITIALIZED
+    private val mutex = Mutex()
+
+    val isInitialized: Boolean
+        get() = cached !== UNINITIALIZED
+
+    @Suppress("UNCHECKED_CAST")
+    fun getOrNull(): T? = cached.takeUnless { it === UNINITIALIZED } as T?
+
+    @Suppress("UNCHECKED_CAST")
+    suspend operator fun invoke(): T {
+        val existing = cached
+        if (existing !== UNINITIALIZED) {
+            return existing as T
+        }
+        return mutex.withLock {
+            val doubleCheck = cached
+            if (doubleCheck !== UNINITIALIZED) {
+                return@withLock doubleCheck as T
+            }
+            initializer().also { cached = it }
+        }
+    }
+
+    private companion object {
+        val UNINITIALIZED = Any()
+    }
+}
+
+/**
+ * Repository на lazySuspend: scope не нужен.
+ */
+class RepositoryLazySuspend(backendApi: BackendApi) {
+    private val cache = lazySuspend { backendApi.apiCall() }
+
+    suspend fun apiCallOrCache(): String = cache()
+}

--- a/tasks/src/main/kotlin/ru/butov/tasks/loadMovie/LoadMovie.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/loadMovie/LoadMovie.kt
@@ -2,6 +2,8 @@ package ru.butov.tasks.loadMovie
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -25,23 +27,25 @@ class LoadService() {
 
 class LoadMovieImpl(
     private val loadService: LoadService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : LoadMovie {
     override fun loadFast(indexes: List<Int>): Flow<String> = indexes.asFlow()
         .fastesLoad(loadService)
 
 
-    override fun loadByOrder(indexes: List<Int>): Flow<String> = indexes.asFlow()
-        .fastesLoad(loadService)
-
+    override fun loadByOrder(indexes: List<Int>): Flow<String> = flow {
+        coroutineScope {
+            val results = indexes.map { index ->
+                async { loadService.loadById(index) }
+            }.awaitAll()
+            results.forEach { emit(it) }
+        }
+    }
 }
 
 private fun Flow<Int>.fastesLoad(loadService: LoadService): Flow<String> =
     this.flatMapMerge { index ->
         flow {
-            println("start index=$index")
             val result = loadService.loadById(index)
-            println("done index=$index result=$result")
             emit(result)
         }
     }

--- a/tasks/src/main/kotlin/ru/butov/tasks/loadMovie/LoadMovie.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/loadMovie/LoadMovie.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
@@ -15,6 +16,7 @@ import kotlinx.coroutines.flow.flowOn
 interface LoadMovie {
     fun loadFast(indexes: List<Int>): Flow<String>
     fun loadByOrder(indexes: List<Int>): Flow<String>
+    fun loadByOrderConcat(indexes: List<Int>): Flow<String>
 }
 
 class LoadService() {
@@ -40,6 +42,13 @@ class LoadMovieImpl(
             results.forEach { emit(it) }
         }
     }
+
+    override fun loadByOrderConcat(indexes: List<Int>): Flow<String> = indexes.asFlow()
+        .flatMapConcat { index ->
+            flow {
+                emit(loadService.loadById(index))
+            }
+        }
 }
 
 private fun Flow<Int>.fastesLoad(loadService: LoadService): Flow<String> =

--- a/tasks/src/main/kotlin/ru/butov/tasks/loadMovie/LoadMovie.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/loadMovie/LoadMovie.kt
@@ -1,0 +1,50 @@
+package ru.butov.tasks.loadMovie
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
+import kotlin.random.Random
+
+interface LoadMovie {
+    fun loadFast(indexes: List<Int>): Flow<String>
+    fun loadAll(indexes: List<Int>): Flow<String>
+}
+
+class LoadService() {
+
+    suspend fun loadById(id: Int): String {
+        delay(id * 1000L)
+        return "movie$id"
+    }
+}
+
+class LoadMovieImpl(
+    private val loadService: LoadService,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) : LoadMovie {
+    override fun loadFast(indexes: List<Int>): Flow<String> = indexes.asFlow()
+        .flatMapMerge {
+            val result = loadService.loadById(it)
+            println("emit $it")
+            flowOf(result)
+        }.flowOn(dispatcher)
+
+
+
+    override fun loadAll(indexes: List<Int>): Flow<String> = flow {
+        indexes.forEach {
+            val result = loadService.loadById(it)
+            println("emit $it")
+            emit(result)
+        }
+    }
+}
+

--- a/tasks/src/main/kotlin/ru/butov/tasks/loadMovie/LoadMovie.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/loadMovie/LoadMovie.kt
@@ -6,17 +6,13 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.flatMapConcat
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
-import kotlin.random.Random
 
 interface LoadMovie {
     fun loadFast(indexes: List<Int>): Flow<String>
-    fun loadAll(indexes: List<Int>): Flow<List<String>>
+    fun loadByOrder(indexes: List<Int>): Flow<String>
 }
 
 class LoadService() {
@@ -32,25 +28,21 @@ class LoadMovieImpl(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : LoadMovie {
     override fun loadFast(indexes: List<Int>): Flow<String> = indexes.asFlow()
-        .flatMapMerge { index ->
-            flow {
-                println("start index=$index")
-                val result = loadService.loadById(index)
-                println("done index=$index result=$result")
-                emit(result)
-            }
-        }
+        .fastesLoad(loadService)
 
 
-    override fun loadAll(indexes: List<Int>): Flow<List<String>> = flow {
-        coroutineScope {
-            indexes.forEach {
-                val result = loadService.loadById(it)
-                println("emit $it")
-              //  emit(result)
-            }
-        }
-    }
+    override fun loadByOrder(indexes: List<Int>): Flow<String> = indexes.asFlow()
+        .fastesLoad(loadService)
 
 }
+
+private fun Flow<Int>.fastesLoad(loadService: LoadService): Flow<String> =
+    this.flatMapMerge { index ->
+        flow {
+            println("start index=$index")
+            val result = loadService.loadById(index)
+            println("done index=$index result=$result")
+            emit(result)
+        }
+    }
 

--- a/tasks/src/main/kotlin/ru/butov/tasks/loadMovie/LoadMovie.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/loadMovie/LoadMovie.kt
@@ -2,6 +2,7 @@ package ru.butov.tasks.loadMovie
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -15,7 +16,7 @@ import kotlin.random.Random
 
 interface LoadMovie {
     fun loadFast(indexes: List<Int>): Flow<String>
-    fun loadAll(indexes: List<Int>): Flow<String>
+    fun loadAll(indexes: List<Int>): Flow<List<String>>
 }
 
 class LoadService() {
@@ -31,20 +32,25 @@ class LoadMovieImpl(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : LoadMovie {
     override fun loadFast(indexes: List<Int>): Flow<String> = indexes.asFlow()
-        .flatMapMerge {
-            val result = loadService.loadById(it)
-            println("emit $it")
-            flowOf(result)
-        }.flowOn(dispatcher)
+        .flatMapMerge { index ->
+            flow {
+                println("start index=$index")
+                val result = loadService.loadById(index)
+                println("done index=$index result=$result")
+                emit(result)
+            }
+        }
 
 
-
-    override fun loadAll(indexes: List<Int>): Flow<String> = flow {
-        indexes.forEach {
-            val result = loadService.loadById(it)
-            println("emit $it")
-            emit(result)
+    override fun loadAll(indexes: List<Int>): Flow<List<String>> = flow {
+        coroutineScope {
+            indexes.forEach {
+                val result = loadService.loadById(it)
+                println("emit $it")
+              //  emit(result)
+            }
         }
     }
+
 }
 

--- a/tasks/src/main/kotlin/ru/butov/tasks/loadMovie/LoadMovie.kt
+++ b/tasks/src/main/kotlin/ru/butov/tasks/loadMovie/LoadMovie.kt
@@ -31,7 +31,12 @@ class LoadMovieImpl(
     private val loadService: LoadService,
 ) : LoadMovie {
     override fun loadFast(indexes: List<Int>): Flow<String> = indexes.asFlow()
-        .fastesLoad(loadService)
+        .flatMapMerge { index ->
+            flow {
+                val result = loadService.loadById(index)
+                emit(result)
+            }
+        }
 
 
     override fun loadByOrder(indexes: List<Int>): Flow<String> = flow {
@@ -50,12 +55,4 @@ class LoadMovieImpl(
             }
         }
 }
-
-private fun Flow<Int>.fastesLoad(loadService: LoadService): Flow<String> =
-    this.flatMapMerge { index ->
-        flow {
-            val result = loadService.loadById(index)
-            emit(result)
-        }
-    }
 

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/ExceptionHandlingTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/ExceptionHandlingTest.kt
@@ -1,0 +1,48 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(DelicateCoroutinesApi::class)
+class ExceptionHandlingTest {
+
+    @Test
+    fun launchVsAsyncExceptionHandling() = runBlocking {
+        val messages = mutableListOf<String>()
+
+        val job = GlobalScope.launch {
+            messages.add("Throwing exception from launch")
+            throw IndexOutOfBoundsException()
+            // Will be printed to the console
+        }
+        job.join()
+        messages.add("Joined failed job")
+
+        val deferred = GlobalScope.async {
+            messages.add("Throwing exception from async")
+            throw ArithmeticException()
+            // Nothing is printed, relying on user to call await
+        }
+
+        var caughtArithmeticException = false
+        try {
+            deferred.await()
+            messages.add("Unreached")
+        } catch (e: ArithmeticException) {
+            messages.add("Caught ArithmeticException")
+            caughtArithmeticException = true
+        }
+
+        assertTrue(messages.contains("Throwing exception from launch"))
+        assertTrue(messages.contains("Joined failed job"))
+        assertTrue(messages.contains("Throwing exception from async"))
+        assertTrue(messages.contains("Caught ArithmeticException"))
+        assertTrue(caughtArithmeticException)
+        assertTrue(!messages.contains("Unreached"))
+    }
+}

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/ExceptionHandlingTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/ExceptionHandlingTest.kt
@@ -3,6 +3,7 @@ package ru.butov.tasks.coroutines
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
@@ -44,5 +45,8 @@ class ExceptionHandlingTest {
         assertTrue(messages.contains("Caught ArithmeticException"))
         assertTrue(caughtArithmeticException)
         assertTrue(!messages.contains("Unreached"))
+
+        println("--- Логи выполнения ---")
+        messages.forEach { println(it) }
     }
 }

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryAsyncLazyTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryAsyncLazyTest.kt
@@ -1,0 +1,84 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RepositoryAsyncLazyTest {
+
+    @Test
+    fun returnsCachedValueOnSecondCall() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryAsyncLazy(
+            backendApi = object : BackendApi {
+                override suspend fun apiCall(): String {
+                    callCount.incrementAndGet()
+                    return "cached"
+                }
+            },
+            scope = this,
+        )
+
+        assertEquals(0, callCount.get())
+        assertEquals("cached", repository.apiCallOrCache())
+        assertEquals("cached", repository.apiCallOrCache())
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun concurrentCallsInvokeApiOnlyOnce() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryAsyncLazy(
+            backendApi = object : BackendApi {
+                override suspend fun apiCall(): String {
+                    callCount.incrementAndGet()
+                    delay(50)
+                    return "result"
+                }
+            },
+            scope = this,
+        )
+
+        coroutineScope {
+            repeat(100) {
+                launch(Dispatchers.Default) {
+                    assertEquals("result", repository.apiCallOrCache())
+                }
+            }
+        }
+
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun concurrentAsyncCallsShareSameResult() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryAsyncLazy(
+            backendApi = object : BackendApi {
+                override suspend fun apiCall(): String {
+                    callCount.incrementAndGet()
+                    delay(50)
+                    return "shared"
+                }
+            },
+            scope = this,
+        )
+
+        val results = coroutineScope {
+            List(50) {
+                async(Dispatchers.Default) { repository.apiCallOrCache() }
+            }.awaitAll()
+        }
+
+        assertTrue(results.all { it == "shared" })
+        assertEquals(1, callCount.get())
+    }
+}

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryAsyncLazyTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryAsyncLazyTest.kt
@@ -24,7 +24,6 @@ class RepositoryAsyncLazyTest {
                     return "cached"
                 }
             },
-            scope = this,
         )
 
         assertEquals(0, callCount.get())
@@ -44,7 +43,6 @@ class RepositoryAsyncLazyTest {
                     return "result"
                 }
             },
-            scope = this,
         )
 
         coroutineScope {
@@ -69,7 +67,6 @@ class RepositoryAsyncLazyTest {
                     return "shared"
                 }
             },
-            scope = this,
         )
 
         val results = coroutineScope {

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryAsyncLazyTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryAsyncLazyTest.kt
@@ -24,6 +24,7 @@ class RepositoryAsyncLazyTest {
                     return "cached"
                 }
             },
+            scope = this,
         )
 
         assertEquals(0, callCount.get())
@@ -43,6 +44,7 @@ class RepositoryAsyncLazyTest {
                     return "result"
                 }
             },
+            scope = this,
         )
 
         coroutineScope {
@@ -67,6 +69,7 @@ class RepositoryAsyncLazyTest {
                     return "shared"
                 }
             },
+            scope = this,
         )
 
         val results = coroutineScope {

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryFlowColdTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryFlowColdTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 class RepositoryFlowColdTest {
 
@@ -26,9 +25,7 @@ class RepositoryFlowColdTest {
             },
         )
 
-        assertNull(repository.cache.value)
         assertEquals("cached", repository.apiCallOrCache().first())
-        assertEquals("cached", repository.cache.value)
         assertEquals("cached", repository.apiCallOrCache().first())
         assertEquals(1, callCount.get())
     }
@@ -55,6 +52,5 @@ class RepositoryFlowColdTest {
         }
 
         assertEquals(1, callCount.get())
-        assertEquals("result", repository.cache.value)
     }
 }

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryFlowColdTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryFlowColdTest.kt
@@ -1,0 +1,60 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RepositoryFlowColdTest {
+
+    @Test
+    fun returnsCachedValueOnSecondCall() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryFlowCold(
+            backendApiFlow = object : BackendApiFlow {
+                override fun apiCall() = flow {
+                    callCount.incrementAndGet()
+                    emit("cached")
+                }
+            },
+        )
+
+        assertNull(repository.cache.value)
+        assertEquals("cached", repository.apiCallOrCache().first())
+        assertEquals("cached", repository.cache.value)
+        assertEquals("cached", repository.apiCallOrCache().first())
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun concurrentCallsInvokeApiOnlyOnce() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryFlowCold(
+            backendApiFlow = object : BackendApiFlow {
+                override fun apiCall() = flow {
+                    callCount.incrementAndGet()
+                    delay(50)
+                    emit("result")
+                }
+            },
+        )
+
+        coroutineScope {
+            repeat(100) {
+                launch(Dispatchers.Default) {
+                    assertEquals("result", repository.apiCallOrCache().first())
+                }
+            }
+        }
+
+        assertEquals(1, callCount.get())
+        assertEquals("result", repository.cache.value)
+    }
+}

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryFlowTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryFlowTest.kt
@@ -17,12 +17,15 @@ class RepositoryFlowTest {
     @Test
     fun returnsCachedValueOnSecondCall() = runBlocking {
         val callCount = AtomicInteger(0)
-        val repository = RepositoryFlow(object : BackendApiFlow {
-            override fun apiCall() = flow {
-                callCount.incrementAndGet()
-                emit("cached")
-            }
-        })
+        val repository = RepositoryFlow(
+            backendApiFlow = object : BackendApiFlow {
+                override fun apiCall() = flow {
+                    callCount.incrementAndGet()
+                    emit("cached")
+                }
+            },
+            scope = this,
+        )
 
         assertNull(repository.cache.value)
         assertEquals("cached", repository.apiCallOrCache().first())
@@ -34,13 +37,16 @@ class RepositoryFlowTest {
     @Test
     fun concurrentCallsInvokeApiOnlyOnce() = runBlocking {
         val callCount = AtomicInteger(0)
-        val repository = RepositoryFlow(object : BackendApiFlow {
-            override fun apiCall() = flow {
-                callCount.incrementAndGet()
-                delay(50)
-                emit("result")
-            }
-        })
+        val repository = RepositoryFlow(
+            backendApiFlow = object : BackendApiFlow {
+                override fun apiCall() = flow {
+                    callCount.incrementAndGet()
+                    delay(50)
+                    emit("result")
+                }
+            },
+            scope = this,
+        )
 
         coroutineScope {
             repeat(100) {

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryFlowTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryFlowTest.kt
@@ -1,0 +1,56 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RepositoryFlowTest {
+
+    @Test
+    fun returnsCachedValueOnSecondCall() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryFlow(object : BackendApiFlow {
+            override fun apiCall() = flow {
+                callCount.incrementAndGet()
+                emit("cached")
+            }
+        })
+
+        assertNull(repository.cache.value)
+        assertEquals("cached", repository.apiCallOrCache().first())
+        assertEquals("cached", repository.cache.value)
+        assertEquals("cached", repository.apiCallOrCache().first())
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun concurrentCallsInvokeApiOnlyOnce() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryFlow(object : BackendApiFlow {
+            override fun apiCall() = flow {
+                callCount.incrementAndGet()
+                delay(50)
+                emit("result")
+            }
+        })
+
+        coroutineScope {
+            repeat(100) {
+                launch(Dispatchers.Default) {
+                    assertEquals("result", repository.apiCallOrCache().first())
+                }
+            }
+        }
+
+        assertEquals(1, callCount.get())
+        assertEquals("result", repository.cache.value)
+    }
+}

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryLazySuspendTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryLazySuspendTest.kt
@@ -1,0 +1,101 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RepositoryLazySuspendTest {
+
+    @Test
+    fun returnsCachedValueOnSecondCall() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryLazySuspend(
+            backendApi = object : BackendApi {
+                override suspend fun apiCall(): String {
+                    callCount.incrementAndGet()
+                    return "cached"
+                }
+            },
+        )
+
+        assertEquals("cached", repository.apiCallOrCache())
+        assertEquals("cached", repository.apiCallOrCache())
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun concurrentCallsInvokeApiOnlyOnce() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryLazySuspend(
+            backendApi = object : BackendApi {
+                override suspend fun apiCall(): String {
+                    callCount.incrementAndGet()
+                    delay(50)
+                    return "result"
+                }
+            },
+        )
+
+        coroutineScope {
+            repeat(100) {
+                launch(Dispatchers.Default) {
+                    assertEquals("result", repository.apiCallOrCache())
+                }
+            }
+        }
+
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun lazySuspendExposesInitializationState() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val lazy = lazySuspend {
+            callCount.incrementAndGet()
+            delay(10)
+            "value"
+        }
+
+        assertFalse(lazy.isInitialized)
+        assertNull(lazy.getOrNull())
+
+        assertEquals("value", lazy())
+        assertTrue(lazy.isInitialized)
+        assertEquals("value", lazy.getOrNull())
+        assertEquals("value", lazy())
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun concurrentAsyncCallsShareSameResult() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryLazySuspend(
+            backendApi = object : BackendApi {
+                override suspend fun apiCall(): String {
+                    callCount.incrementAndGet()
+                    delay(50)
+                    return "shared"
+                }
+            },
+        )
+
+        val results = coroutineScope {
+            List(50) {
+                async(Dispatchers.Default) { repository.apiCallOrCache() }
+            }.awaitAll()
+        }
+
+        assertTrue(results.all { it == "shared" })
+        assertEquals(1, callCount.get())
+    }
+}

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryLazyTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryLazyTest.kt
@@ -1,0 +1,56 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+
+class RepositoryLazyTest {
+
+    @Test
+    fun returnsCachedValueOnSecondCall() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryLazy(
+            backendApi = object : BackendApi {
+                override suspend fun apiCall(): String {
+                    callCount.incrementAndGet()
+                    return "cached"
+                }
+            },
+            scope = this,
+        )
+
+        assertEquals("cached", repository.apiCallOrCache())
+        assertEquals("cached", repository.apiCallOrCache())
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun concurrentCallsInvokeApiOnlyOnce() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryLazy(
+            backendApi = object : BackendApi {
+                override suspend fun apiCall(): String {
+                    callCount.incrementAndGet()
+                    delay(50)
+                    return "result"
+                }
+            },
+            scope = this,
+        )
+
+        coroutineScope {
+            repeat(100) {
+                launch(Dispatchers.Default) {
+                    assertEquals("result", repository.apiCallOrCache())
+                }
+            }
+        }
+
+        assertEquals(1, callCount.get())
+    }
+}

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryLazyTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryLazyTest.kt
@@ -1,6 +1,8 @@
 package ru.butov.tasks.coroutines
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -8,6 +10,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class RepositoryLazyTest {
 
@@ -51,6 +54,30 @@ class RepositoryLazyTest {
             }
         }
 
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun concurrentAsyncCallsShareSameDeferred() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = RepositoryLazy(
+            backendApi = object : BackendApi {
+                override suspend fun apiCall(): String {
+                    callCount.incrementAndGet()
+                    delay(50)
+                    return "shared"
+                }
+            },
+            scope = this,
+        )
+
+        val results = coroutineScope {
+            List(50) {
+                async(Dispatchers.Default) { repository.apiCallOrCache() }
+            }.awaitAll()
+        }
+
+        assertTrue(results.all { it == "shared" })
         assertEquals(1, callCount.get())
     }
 }

--- a/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/coroutines/RepositoryTest.kt
@@ -1,0 +1,50 @@
+package ru.butov.tasks.coroutines
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+
+class RepositoryTest {
+
+    @Test
+    fun returnsCachedValueOnSecondCall() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = Repository(object : BackendApi {
+            override suspend fun apiCall(): String {
+                callCount.incrementAndGet()
+                return "cached"
+            }
+        })
+
+        assertEquals("cached", repository.apiCallOrCache())
+        assertEquals("cached", repository.apiCallOrCache())
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun concurrentCallsInvokeApiOnlyOnce() = runBlocking {
+        val callCount = AtomicInteger(0)
+        val repository = Repository(object : BackendApi {
+            override suspend fun apiCall(): String {
+                callCount.incrementAndGet()
+                delay(50)
+                return "result"
+            }
+        })
+
+        coroutineScope {
+            repeat(100) {
+                launch(Dispatchers.Default) {
+                    assertEquals("result", repository.apiCallOrCache())
+                }
+            }
+        }
+
+        assertEquals(1, callCount.get())
+    }
+}

--- a/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
@@ -21,14 +21,14 @@ class LoadMovieTest {
     @Test
     fun loadByOrder() = runTest {
         val loadMovie = LoadMovieImpl(LoadService())
-        val result = loadMovie.loadByOrder(listOf(3, 2, 1)).toList()
-        assertEquals(listOf("movie3", "movie2", "movie1"), result)
+        val result = loadMovie.loadByOrder(listOf(1, 2, 3)).toList()
+        assertEquals(listOf("movie1", "movie2", "movie3"), result)
     }
 
     @Test
     fun loadByOrderConcat() = runTest {
         val loadMovie = LoadMovieImpl(LoadService())
-        val result = loadMovie.loadByOrderConcat(listOf(3, 2, 1)).toList()
-        assertEquals(listOf("movie3", "movie2", "movie1"), result)
+        val result = loadMovie.loadByOrderConcat(listOf(1, 2, 3)).toList()
+        assertEquals(listOf("movie1", "movie2", "movie3"), result)
     }
 }

--- a/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
@@ -12,14 +12,14 @@ import kotlin.test.assertEquals
 class LoadMovieTest {
 
     @Test
-    fun loadFast() = runBlocking {
+    fun loadFast() = runTest {
         val loadMovie = LoadMovieImpl(LoadService())
         val result = loadMovie.loadFast(listOf(3,2,1)).toList()
         assertEquals(listOf("movie1", "movie2", "movie3"), result)
     }
 
     @Test
-    fun loadAll() = runBlocking {
+    fun loadAll() = runTest {
         val loadMovie = LoadMovieImpl(LoadService())
         val result = loadMovie.loadByOrder(listOf(1,2,3)).toList()
         assertEquals(listOf("movie1", "movie2", "movie3"), result)

--- a/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
@@ -13,16 +13,15 @@ class LoadMovieTest {
 
     @Test
     fun loadFast() = runBlocking {
-        val loadMovie = LoadMovieImpl(LoadService(), Dispatchers.IO)
+        val loadMovie = LoadMovieImpl(LoadService())
         val result = loadMovie.loadFast(listOf(3,2,1)).toList()
-
         assertEquals(listOf("movie1", "movie2", "movie3"), result)
     }
 
     @Test
-    fun loadAll() = runTest {
+    fun loadAll() = runBlocking {
         val loadMovie = LoadMovieImpl(LoadService())
         val result = loadMovie.loadByOrder(listOf(1,2,3)).toList()
-     //   assertEquals(listOf("movie3", "movie2", "movie1"), result)
+        assertEquals(listOf("movie1", "movie2", "movie3"), result)
     }
 }

--- a/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -23,7 +22,7 @@ class LoadMovieTest {
     @Test
     fun loadAll() = runTest {
         val loadMovie = LoadMovieImpl(LoadService())
-        val result = loadMovie.loadAll(listOf(1,2,3)).toList()
+        val result = loadMovie.loadByOrder(listOf(1,2,3)).toList()
      //   assertEquals(listOf("movie3", "movie2", "movie1"), result)
     }
 }

--- a/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
@@ -1,7 +1,9 @@
 package ru.butov.tasks.loadMovie
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -10,20 +12,18 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalCoroutinesApi::class)
 class LoadMovieTest {
 
-    val indexies
-        get() = listOf(3, 2, 1)
-
     @Test
-    fun loadFast() = runTest {
-        val loadMovie = LoadMovieImpl(LoadService(), UnconfinedTestDispatcher(testScheduler))
-        val result = loadMovie.loadFast(indexies).toList()
-        assertEquals(listOf("movie3", "movie2", "movie1"), result)
+    fun loadFast() = runBlocking {
+        val loadMovie = LoadMovieImpl(LoadService(), Dispatchers.IO)
+        val result = loadMovie.loadFast(listOf(3,2,1)).toList()
+
+        assertEquals(listOf("movie1", "movie2", "movie3"), result)
     }
 
     @Test
     fun loadAll() = runTest {
         val loadMovie = LoadMovieImpl(LoadService())
-        val result = loadMovie.loadAll(indexies).toList()
-        assertEquals(listOf("movie3", "movie2", "movie1"), result)
+        val result = loadMovie.loadAll(listOf(1,2,3)).toList()
+     //   assertEquals(listOf("movie3", "movie2", "movie1"), result)
     }
 }

--- a/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
@@ -1,0 +1,29 @@
+package ru.butov.tasks.loadMovie
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LoadMovieTest {
+
+    val indexies
+        get() = listOf(3, 2, 1)
+
+    @Test
+    fun loadFast() = runTest {
+        val loadMovie = LoadMovieImpl(LoadService(), UnconfinedTestDispatcher(testScheduler))
+        val result = loadMovie.loadFast(indexies).toList()
+        assertEquals(listOf("movie3", "movie2", "movie1"), result)
+    }
+
+    @Test
+    fun loadAll() = runTest {
+        val loadMovie = LoadMovieImpl(LoadService())
+        val result = loadMovie.loadAll(indexies).toList()
+        assertEquals(listOf("movie3", "movie2", "movie1"), result)
+    }
+}

--- a/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
+++ b/tasks/src/test/kotlin/ru/butov/tasks/loadMovie/LoadMovieTest.kt
@@ -19,9 +19,16 @@ class LoadMovieTest {
     }
 
     @Test
-    fun loadAll() = runTest {
+    fun loadByOrder() = runTest {
         val loadMovie = LoadMovieImpl(LoadService())
-        val result = loadMovie.loadByOrder(listOf(1,2,3)).toList()
-        assertEquals(listOf("movie1", "movie2", "movie3"), result)
+        val result = loadMovie.loadByOrder(listOf(3, 2, 1)).toList()
+        assertEquals(listOf("movie3", "movie2", "movie1"), result)
+    }
+
+    @Test
+    fun loadByOrderConcat() = runTest {
+        val loadMovie = LoadMovieImpl(LoadService())
+        val result = loadMovie.loadByOrderConcat(listOf(3, 2, 1)).toList()
+        assertEquals(listOf("movie3", "movie2", "movie1"), result)
     }
 }


### PR DESCRIPTION
## Summary
- LoadMovie flow variants (ordered / fast / concat)
- Thread-safe Repository cache examples: Mutex, stateIn, cold Flow, lazy+async, LazySuspend, async(LAZY)
- Concurrency tests for single API call under parallel access

## Test plan
- [x] Repository* and LoadMovie tests